### PR TITLE
Support query suffix

### DIFF
--- a/plugin/websearch.vim
+++ b/plugin/websearch.vim
@@ -130,6 +130,9 @@ function! DoWebSearch(string) "{{{2
     " default search engine is duckduckgo
     let l:query = l:duckduck . l:term
   endif
+  if exists("g:web_search_query_suffix")
+    let l:query = l:query . g:web_search_query_suffix
+  endif
   if exists("g:web_search_browser")
     if g:web_search_browser == "lynx"
       let l:browser_cmd = l:lynx


### PR DESCRIPTION
It is useful for things like that when using DuckDuckGo:
```viml
let g:web_search_query_suffix = ' \!'
```